### PR TITLE
remove /konfetti/ prefix in links

### DIFF
--- a/content/kinderbetreuung/kinderbetreuung.md
+++ b/content/kinderbetreuung/kinderbetreuung.md
@@ -5,7 +5,7 @@ draft = false
 
 +++
 
-Konfetti e.V. ist eine [Eltern-Kind-Initiative](/konfetti/eltern-initiativ) mit [Krippe](/konfetti/kinderbetreuung/krippe/), [Kindergarten](/konfetti/kinderbetreuung/kindergarten/) und [Hort](/konfetti/kinderbetreuung/hort/).
+Konfetti e.V. ist eine [Eltern-Kind-Initiative](/eltern-initiativ/) mit [Krippe](/kinderbetreuung/krippe/), [Kindergarten](/kinderbetreuung/kindergarten/) und [Hort](/kinderbetreuung/hort/).
 
 Die Stärke unserer Initiative liegt in unserem stabilen Betreuerteam. Der Betreuungsschlüssel ist mit insgesamt 5 pädagogischen Fachkräften, dazu kommen qualifizierte Teilzeitkräfte, FSJlerInnen und Praktikantinnen hervorragend. Konfetti hat eine Betriebserlaubnis für 37 Kinder.
 

--- a/content/ueber-uns/ueber-uns.md
+++ b/content/ueber-uns/ueber-uns.md
@@ -4,14 +4,14 @@ draft = false
 
 +++
 
-Die Elterninitiative Konfetti e.V. im Herzen des Münchner Glockenbachviertels ist [Krippe](/konfetti/kinderbetreuung/krippe), [Kindergarten](/konfetti/kinderbetreuung/kindergarten) und [Hort](/konfetti/kinderbetreuung/hort) für Kinder im Alter von 1 bis 10 Jahren, bis zum Ende der Grundschule. Das altersgemischte Konzept bietet eine langfristige Perspektive für Eltern und Kinder.
+Die Elterninitiative Konfetti e.V. im Herzen des Münchner Glockenbachviertels ist [Krippe](/kinderbetreuung/krippe), [Kindergarten](/kinderbetreuung/kindergarten) und [Hort](/kinderbetreuung/hort) für Kinder im Alter von 1 bis 10 Jahren, bis zum Ende der Grundschule. Das altersgemischte Konzept bietet eine langfristige Perspektive für Eltern und Kinder.
 
 Sowohl Krippen-, als auch Kindergarten- und Hortkinder werden in regelmäßigen Arbeitsgruppen in ihrer Entwicklung motiviert und gefördert. Sämtliche Eltern wirken in monatlichen Elternabenden, Elterndiensten sowie bei der übernahme von organisatorischen Aufgaben mit.
 
-Zudem sorgt ein erfahrenes und hochqualifiziertes [Erzieherinnenteam](/konfetti/ueber-uns/team), eine Kinderpflegerin und zwei FSJlerInnen für die bestmögliche Betreuung und Entwicklung der Krippen-, Kindergarten- und Hortkinder.
+Zudem sorgt ein erfahrenes und hochqualifiziertes [Erzieherinnenteam](/ueber-uns/team), eine Kinderpflegerin und zwei FSJlerInnen für die bestmögliche Betreuung und Entwicklung der Krippen-, Kindergarten- und Hortkinder.
 
-[Team](/konfetti/ueber-uns/team)<br/>
-[Stellenausschreibungen](/konfetti/ueber-uns/stellenausschreibungen)<br/>
-[Zeiten & Preise](/konfetti/ueber-uns/zeiten-und-preise)<br/>
-[Förderer & Sponsoren](/konfetti/ueber-uns/foerderer-und-sponsoren)<br/>
-[Kontakt](/konfetti/ueber-uns/kontakt)<br/>
+[Team](/ueber-uns/team)<br/>
+[Stellenausschreibungen](/ueber-uns/stellenausschreibungen)<br/>
+[Zeiten & Preise](/ueber-uns/zeiten-und-preise)<br/>
+[Förderer & Sponsoren](/ueber-uns/foerderer-und-sponsoren)<br/>
+[Kontakt](/ueber-uns/kontakt)<br/>


### PR DESCRIPTION
Most links included an unnecessary `/konfetti/` prefix that actually broke the links. This removes that.